### PR TITLE
Add `config-server` label to deployment

### DIFF
--- a/manifests/deployment.yml
+++ b/manifests/deployment.yml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: config-server
+        app: config-server
     spec:
       containers:
         - name: users


### PR DESCRIPTION
New label `config-server` added to config-server pods